### PR TITLE
Allow more fields in create action & return issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-jira",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JupiterOne managed integration for https://www.atlassian.com/software/jira.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/jupiter-integration-jira",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jira-client": "^6.7.1"
   },
   "peerDependencies": {
-    "@jupiterone/jupiter-managed-integration-sdk": "^23.1.0"
+    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -41,7 +41,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
-    "@jupiterone/jupiter-managed-integration-sdk": "^23.1.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.3",
     "@types/bunyan": "^1.8.5",
     "@types/fs-extra": "^7.0.0",
     "@types/jest": "^24.0.0",

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -52,7 +52,7 @@ async function createIssue(
     event: { action },
   } = context;
 
-  const jiraData = await createJiraIssue(
+  const { data: jiraData, issue } = await createJiraIssue(
     jira,
     action as IntegrationCreateEntityAction,
   );
@@ -71,6 +71,10 @@ async function createIssue(
     operations: summarizePersisterOperationsResults(
       await publishChanges(persister, emptyOldData, jiraData),
     ),
+    actionResult: {
+      name: IntegrationActionName.INGEST,
+      entities: [issue],
+    },
   };
 }
 

--- a/src/jira/JiraClient.ts
+++ b/src/jira/JiraClient.ts
@@ -34,6 +34,7 @@ export default class JiraClient {
     summary: string,
     projectId: number,
     issueTypeName: IssueTypeName,
+    additionalFields: object = {},
   ): Promise<Issue> {
     const issue: Issue = (await this.client.addNewIssue({
       fields: {
@@ -44,6 +45,7 @@ export default class JiraClient {
         issuetype: {
           name: issueTypeName,
         },
+        ...additionalFields,
       },
     })) as Issue;
     return issue;

--- a/src/jira/createJiraIssue.ts
+++ b/src/jira/createJiraIssue.ts
@@ -7,11 +7,12 @@ import { Issue, JiraDataModel, Project, ServerInfo } from "./types";
 export default async function createJiraIssue(
   client: JiraClient,
   action: IntegrationCreateEntityAction,
-): Promise<JiraDataModel> {
+): Promise<{ data: JiraDataModel; issue: Issue }> {
   const {
     summary,
     classification,
     project,
+    additionalFields,
   } = action.properties as CreateIssueActionProperties;
 
   // TODO resolve project id using project key??
@@ -20,14 +21,18 @@ export default async function createJiraIssue(
     summary,
     Number(project),
     classification as any,
+    additionalFields,
   );
   const issueFullData: Issue = (await client.findIssue(newIssue.key)) as Issue;
   const issues = ([] as Issue[]).concat(issueFullData);
 
   return {
-    projects: [] as Project[],
-    serverInfo: {} as ServerInfo,
-    users: [],
-    issues,
+    data: {
+      projects: [] as Project[],
+      serverInfo: {} as ServerInfo,
+      users: [],
+      issues,
+    },
+    issue: issueFullData,
   };
 }

--- a/src/persister/publishChanges.test.ts
+++ b/src/persister/publishChanges.test.ts
@@ -480,18 +480,18 @@ describe("Convert data after creating issue", () => {
     });
     const { jira } = await initialize();
 
-    const newData = convert(
-      await createJiraIssue(jira, {
-        name: IntegrationActionName.CREATE_ENTITY,
-        class: "Vulnerability",
-        properties: {
-          summary: "Test Summary",
-          description: "Test Description",
-          classification: "Task",
-          project: "10000",
-        },
-      } as IntegrationCreateEntityAction),
-    );
+    const { data: issueData } = await createJiraIssue(jira, {
+      name: IntegrationActionName.CREATE_ENTITY,
+      class: "Vulnerability",
+      properties: {
+        summary: "Test Summary",
+        description: "Test Description",
+        classification: "Task",
+        project: "10000",
+      },
+    } as IntegrationCreateEntityAction);
+
+    const newData = convert(issueData);
     nockDone();
     expect(newData.entities.issues).toEqual([
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface CreateIssueActionProperties {
   project: string;
   summary: string;
   classification: string;
+  additionalFields?: object;
 }
 
 export interface JiraIntegrationContext extends IntegrationExecutionContext {

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,10 +844,10 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@jupiterone/jupiter-managed-integration-sdk@^23.1.0":
-  version "23.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-23.1.0.tgz#c52505ba3808cbe69f459f9dbeffa91a3a2472b9"
-  integrity sha512-x7go4Ze3lx4D02mPvpcHSRI6ul94ng4qbUuc+cdrx1c6DVdiZfAN4loGNyHuw/mlHTveV3w/rzEkq/F5VLy8Dg==
+"@jupiterone/jupiter-managed-integration-sdk@^24.0.3":
+  version "24.0.3"
+  resolved "https://registry.npmjs.org/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-24.0.3.tgz#08341dc8e0fdb5b319e46dec5e60394a52044a75"
+  integrity sha512-Qif5J3glncNThi3DM2cMExFYebIEuuqu/bQPFOTdvKwN44WtZBTSXqgNDqnfSnkZpsu7eYmt+8bkup0ke7WX4A==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
Using this action:

```
const jiraCreateEntityProperties: CreateIssueActionProperties = {
  summary: "Test Summary",
  classification: "Task",
  project: "10313", // "10202" // "10303",
  additionalFields: {
    description: {
      type: "doc",
      version: 1,
      content: [
        {
          type: "paragraph",
          content: [
            {
              text: "suh dude",
              type: "text",
            },
          ],
        },
      ],
    },
  },
};
```

I got this issue in J1TEMP: https://lifeomic.atlassian.net/browse/J1TEMP-59